### PR TITLE
Changes for probe config

### DIFF
--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -15,14 +15,14 @@ spec:
             httpGet:
               port: 8080
               path: /actuator/info
-            initialDelaySeconds: 30
-            periodSeconds: 30
+            initialDelaySeconds: 50
+            periodSeconds: 20
           readinessProbe:
             httpGet:
               port: 8080
               path: /actuator/info
-            initialDelaySeconds: 30
-            periodSeconds: 30
+            initialDelaySeconds: 50
+            periodSeconds: 20
           volumeMounts:
             - name: secret
               mountPath: "/usr/local/tomcat/webapps/ROOT/WEB-INF/classes/thumbnail.user.properties"

--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -14,13 +14,13 @@ spec:
           livenessProbe:
             httpGet:
               port: 8080
-              path: /actuator/info
+              path: /actuator/health/liveness
             initialDelaySeconds: 50
             periodSeconds: 20
           readinessProbe:
             httpGet:
               port: 8080
-              path: /actuator/info
+              path: /actuator/health/readiness
             initialDelaySeconds: 50
             periodSeconds: 20
           volumeMounts:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,10 +11,22 @@ management:
   endpoints:
     web:
       exposure:
-        include: info
+        include: info, health
 
   info:
     env:
+      enabled: true
+
+  endpoint:
+    health:
+      probes:
+        enabled: true
+      show-details: always
+
+  health:
+    livenessState:
+      enabled: true
+    readinessState:
       enabled: true
 
 # Creates a redirect from /console to /swagger-ui/index.html


### PR DESCRIPTION
New values are based on analysis of max-min application startup time from prod /acceptance/test environment
observed (max-min) 43.938- 37.835 seconds for thumbnail api